### PR TITLE
Supabase-backed airing schedule, RLS, faster Schedule tab

### DIFF
--- a/.github/workflows/daily_anilist_update.yml
+++ b/.github/workflows/daily_anilist_update.yml
@@ -12,13 +12,13 @@ jobs:
   update-anilist-data:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           persist-credentials: true
           token: ${{ github.token }}
       
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       
@@ -84,7 +84,7 @@ jobs:
 
       - name: Create Issue on Failure
         if: failure()
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             github.rest.issues.create({

--- a/.github/workflows/daily_jikan_update.yml
+++ b/.github/workflows/daily_jikan_update.yml
@@ -12,13 +12,13 @@ jobs:
   update-jikan-data:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           persist-credentials: true
           token: ${{ github.token }}
       
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       
@@ -81,7 +81,7 @@ jobs:
 
       - name: Create Issue on Failure
         if: failure()
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             github.rest.issues.create({

--- a/.github/workflows/daily_supabase_sync.yml
+++ b/.github/workflows/daily_supabase_sync.yml
@@ -21,11 +21,11 @@ jobs:
     if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/daily_update.yml
+++ b/.github/workflows/daily_update.yml
@@ -12,13 +12,13 @@ jobs:
   update-data:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           persist-credentials: true
           token: ${{ github.token }}
       
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       
@@ -83,7 +83,7 @@ jobs:
 
       - name: Create Issue on Failure
         if: failure()
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             github.rest.issues.create({

--- a/frontend/app/api/schedule/route.ts
+++ b/frontend/app/api/schedule/route.ts
@@ -1,0 +1,135 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { supabase } from '@/lib/supabase'
+
+const TABLE_CANDIDATES = ['airing_schedule_active', 'airing_schedule'] as const
+const PAGE_SIZE = 1000
+const MAX_RANGE_DAYS = 62
+
+type ScheduleRow = {
+  id: number
+  schedule_id: number | null
+  anime_id: number
+  episode: number
+  airing_at: string
+  title: string | null
+  cover_image: string | null
+  score: number | null
+  total_episodes: number | null
+  anime_status: string | null
+}
+
+function parseDate(value: string | null): Date | null {
+  if (!value || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return null
+  const parsed = new Date(`${value}T00:00:00Z`)
+  return Number.isNaN(parsed.getTime()) ? null : parsed
+}
+
+function airingStatus(airingAtMs: number, nowMs: number): string {
+  if (airingAtMs <= nowMs) return 'aired'
+  if (airingAtMs - nowMs <= 60 * 60 * 1000) return 'airing_soon'
+  const airing = new Date(airingAtMs)
+  const now = new Date(nowMs)
+  if (airing.toDateString() === now.toDateString()) return 'airing_today'
+  return 'upcoming'
+}
+
+function formatTimeUntil(airingAtMs: number, nowMs: number): string {
+  const diffSeconds = Math.round((airingAtMs - nowMs) / 1000)
+  const abs = Math.abs(diffSeconds)
+  const days = Math.floor(abs / 86400)
+  const hours = Math.floor((abs % 86400) / 3600)
+  const minutes = Math.floor((abs % 3600) / 60)
+
+  let label: string
+  if (days > 0) label = `${days}d ${hours}h`
+  else if (hours > 0) label = `${hours}h ${minutes}m`
+  else label = `${minutes}m`
+
+  return diffSeconds >= 0 ? `in ${label}` : `${label} ago`
+}
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams
+
+  const now = new Date()
+  const defaultStart = new Date(now)
+  defaultStart.setUTCDate(defaultStart.getUTCDate() - 7)
+  const defaultEnd = new Date(now)
+  defaultEnd.setUTCDate(defaultEnd.getUTCDate() + 7)
+
+  const start = parseDate(searchParams.get('start')) ?? defaultStart
+  const end = parseDate(searchParams.get('end')) ?? defaultEnd
+
+  if (end <= start) {
+    return NextResponse.json({ error: 'end must be after start' }, { status: 400 })
+  }
+  if ((end.getTime() - start.getTime()) / 86400000 > MAX_RANGE_DAYS) {
+    return NextResponse.json({ error: `range too large (max ${MAX_RANGE_DAYS} days)` }, { status: 400 })
+  }
+
+  let rows: ScheduleRow[] | null = null
+  let lastError: { message: string } | null = null
+
+  for (const tableName of TABLE_CANDIDATES) {
+    const collected: ScheduleRow[] = []
+    let pageError: { message: string } | null = null
+
+    for (let from = 0; ; from += PAGE_SIZE) {
+      const result = await supabase
+        .from(tableName)
+        .select('id, schedule_id, anime_id, episode, airing_at, title, cover_image, score, total_episodes, anime_status')
+        .gte('airing_at', start.toISOString())
+        .lt('airing_at', end.toISOString())
+        .order('airing_at')
+        .range(from, from + PAGE_SIZE - 1)
+
+      if (result.error) {
+        pageError = result.error
+        break
+      }
+
+      collected.push(...((result.data || []) as ScheduleRow[]))
+      if (!result.data || result.data.length < PAGE_SIZE) break
+    }
+
+    if (!pageError) {
+      rows = collected
+      lastError = null
+      break
+    }
+
+    lastError = pageError
+    if (tableName !== 'airing_schedule_active') break
+  }
+
+  if (lastError) {
+    return NextResponse.json({ error: lastError.message }, { status: 500 })
+  }
+
+  const nowMs = Date.now()
+  const items = (rows || []).map((row) => {
+    const airingAtMs = new Date(row.airing_at).getTime()
+    return {
+      schedule_id: row.schedule_id ?? row.id,
+      anime_id: row.anime_id,
+      episode: row.episode,
+      airing_at: Math.round(airingAtMs / 1000),
+      title: row.title || 'Unknown',
+      cover_image: row.cover_image,
+      status: row.anime_status,
+      total_episodes: row.total_episodes,
+      score: row.score,
+      airing_status: airingStatus(airingAtMs, nowMs),
+      airs_in_human: formatTimeUntil(airingAtMs, nowMs),
+      airing_time: new Date(airingAtMs).toISOString().slice(11, 16),
+      airing_date: new Date(airingAtMs).toISOString().slice(0, 10),
+    }
+  })
+
+  return NextResponse.json({
+    start: start.toISOString().slice(0, 10),
+    end: end.toISOString().slice(0, 10),
+    total: items.length,
+    items,
+  })
+}

--- a/frontend/components/MonthlySchedule.tsx
+++ b/frontend/components/MonthlySchedule.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useMemo, useCallback } from 'react'
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Calendar, Clock, ChevronLeft, ChevronRight, X, Loader2, Sparkles, Star, Trophy } from 'lucide-react'
@@ -26,8 +26,6 @@ interface MonthlyScheduleProps {
   initialSelectedDate?: string | null
   onStateChange?: (date: Date, selectedDate: string | null) => void
 }
-
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
 
 const DAYS_OF_WEEK = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
 const MONTH_NAMES = ['January', 'February', 'March', 'April', 'May', 'June',
@@ -56,7 +54,7 @@ export default function MonthlySchedule({
 
   const [scheduleData, setScheduleData] = useState<Map<string, ScheduleItem[]>>(new Map())
   const [loading, setLoading] = useState(true)
-  const [loadingProgress, setLoadingProgress] = useState(0)
+  const rangeCache = useRef<Map<string, Map<string, ScheduleItem[]>>>(new Map())
 
   const todayKey = formatLocalDateKey(new Date())
   const [currentDate, setCurrentDate] = useState(initialDate || new Date())
@@ -88,36 +86,9 @@ export default function MonthlySchedule({
     return days
   }, [currentDate])
 
-  const weeksToFetch = useMemo(() => {
-    const today = new Date()
-    today.setHours(0, 0, 0, 0)
-
-    const currentMonday = new Date(today)
-    const dayOfWeek = today.getDay()
-    const daysToMonday = dayOfWeek === 0 ? -6 : 1 - dayOfWeek
-    currentMonday.setDate(today.getDate() + daysToMonday)
-
-    const firstCalendarDay = calendarDays[0]
-    const weeks: number[] = []
-    const msPerWeek = 7 * 24 * 60 * 60 * 1000
-
-    const firstWeekMonday = new Date(firstCalendarDay)
-    const firstDayOfWeek = firstCalendarDay.getDay()
-    const daysToFirstMonday = firstDayOfWeek === 0 ? -6 : 1 - firstDayOfWeek
-    firstWeekMonday.setDate(firstCalendarDay.getDate() + daysToFirstMonday)
-
-    const startOffset = Math.round((firstWeekMonday.getTime() - currentMonday.getTime()) / msPerWeek)
-
-    for (let i = 0; i < 6; i++) {
-      weeks.push(startOffset + i)
-    }
-
-    return weeks
-  }, [calendarDays])
-
   useEffect(() => {
     loadMonthSchedule()
-  }, [weeksToFetch])
+  }, [calendarDays])
 
   useEffect(() => {
     if (selectedDate && scheduleData.size > 0) {
@@ -131,48 +102,54 @@ export default function MonthlySchedule({
   }, [currentDate, selectedDate, onStateChange])
 
   const loadMonthSchedule = async () => {
+    // Fetch the whole visible calendar range in one request, padded a day on
+    // each side so local-timezone grouping never misses boundary episodes.
+    const rangeStart = new Date(calendarDays[0])
+    rangeStart.setDate(rangeStart.getDate() - 1)
+    const rangeEnd = new Date(calendarDays[calendarDays.length - 1])
+    rangeEnd.setDate(rangeEnd.getDate() + 2)
+
+    const startKey = formatLocalDateKey(rangeStart)
+    const endKey = formatLocalDateKey(rangeEnd)
+    const cacheKey = `${startKey}_${endKey}`
+
+    const cached = rangeCache.current.get(cacheKey)
+    if (cached) {
+      setScheduleData(cached)
+      applyDefaultSelection(cached)
+      return
+    }
+
     setLoading(true)
-    setLoadingProgress(0)
     const newScheduleData = new Map<string, ScheduleItem[]>()
 
     try {
-      let completedWeeks = 0
+      const res = await fetch(`/api/schedule?start=${startKey}&end=${endKey}`)
+      const data = await res.json()
 
-      for (const offset of weeksToFetch) {
-        try {
-          const res = await fetch(`${API_URL}/anime/schedule/weekly?weeks_offset=${offset}`)
-          const weekData = await res.json()
-
-          if (weekData?.schedule) {
-            Object.entries(weekData.schedule).forEach(([, items]) => {
-              (items as ScheduleItem[]).forEach(item => {
-                const airingDate = new Date(item.airing_at * 1000)
-                const localDateKey = formatLocalDateKey(airingDate)
-
-                if (!newScheduleData.has(localDateKey)) {
-                  newScheduleData.set(localDateKey, [])
-                }
-                newScheduleData.get(localDateKey)!.push({
-                  ...item,
-                  airing_date: localDateKey
-                })
-              })
-            })
-          }
-        } catch (err) {
-          console.warn(`Failed to fetch week ${offset}:`, err)
+      for (const item of (data.items || []) as ScheduleItem[]) {
+        const localDateKey = formatLocalDateKey(new Date(item.airing_at * 1000))
+        if (!newScheduleData.has(localDateKey)) {
+          newScheduleData.set(localDateKey, [])
         }
-
-        completedWeeks++
-        setLoadingProgress(Math.round((completedWeeks / weeksToFetch.length) * 100))
-
-        if (completedWeeks < weeksToFetch.length) {
-          await new Promise(resolve => setTimeout(resolve, 100))
-        }
+        newScheduleData.get(localDateKey)!.push({
+          ...item,
+          airing_date: localDateKey
+        })
       }
 
+      rangeCache.current.set(cacheKey, newScheduleData)
       setScheduleData(newScheduleData)
+      applyDefaultSelection(newScheduleData)
+    } catch (error) {
+      console.error('Failed to load monthly schedule:', error)
+    } finally {
+      setLoading(false)
+    }
+  }
 
+  const applyDefaultSelection = (newScheduleData: Map<string, ScheduleItem[]>) => {
+    {
       if (!selectedDate || !newScheduleData.has(selectedDate)) {
         const today = new Date()
         const todayStr = formatLocalDateKey(today)
@@ -205,11 +182,6 @@ export default function MonthlySchedule({
           }
         }
       }
-    } catch (error) {
-      console.error('Failed to load monthly schedule:', error)
-    } finally {
-      setLoading(false)
-      setLoadingProgress(100)
     }
   }
 
@@ -258,23 +230,6 @@ export default function MonthlySchedule({
   // Premium Loading Skeleton
   const LoadingSkeleton = () => (
     <div className="glass-card p-6">
-      {/* Progress indicator */}
-      <div className="mb-6 space-y-3">
-        <div className="flex items-center justify-between text-sm">
-          <span className="text-muted-foreground flex items-center gap-2">
-            <Loader2 className="w-4 h-4 animate-spin text-primary" />
-            <span>Loading schedule...</span>
-          </span>
-          <span className="text-primary font-semibold">{loadingProgress}%</span>
-        </div>
-        <div className="h-2 bg-muted/50 rounded-full overflow-hidden">
-          <div
-            className="h-full progress-glow transition-all duration-300 ease-out"
-            style={{ width: `${loadingProgress}%` }}
-          />
-        </div>
-      </div>
-
       {/* Day Headers */}
       <div className="grid grid-cols-7 gap-2 mb-3">
         {DAYS_OF_WEEK.map(day => (

--- a/src/supabase_client.py
+++ b/src/supabase_client.py
@@ -353,12 +353,45 @@ class SupabaseClient:
             print(f"Error upserting schedule: {e}")
             return None
 
+    def upsert_schedule_batch(
+        self,
+        schedule_list: List[Dict[str, Any]],
+        batch_size: int = 200,
+        version_id: Optional[int] = None
+    ) -> int:
+        """
+        Batch upsert airing schedule entries (denormalized rows).
+        Returns count of successfully upserted records.
+        """
+        total_upserted = 0
+        resolved_version_id = self._resolve_dataset_version_id(version_id)
+        on_conflict = (
+            'dataset_version_id,anime_id,episode'
+            if self.supports_dataset_versioning() else 'anime_id,episode'
+        )
+
+        for i in range(0, len(schedule_list), batch_size):
+            batch = []
+            for item in schedule_list[i:i + batch_size]:
+                row = dict(item)
+                if self.supports_dataset_versioning() and resolved_version_id is not None:
+                    row['dataset_version_id'] = resolved_version_id
+                batch.append(row)
+
+            result = self.client.table('airing_schedule').upsert(
+                batch,
+                on_conflict=on_conflict
+            ).execute()
+            total_upserted += len(result.data) if result.data else 0
+
+        return total_upserted
+
     def get_schedule_for_date(self, date: datetime) -> List[Dict]:
         """Get all episodes airing on a specific date"""
         start_of_day = date.replace(hour=0, minute=0, second=0, microsecond=0)
         end_of_day = date.replace(hour=23, minute=59, second=59, microsecond=999999)
 
-        query = self.client.table('airing_schedule').select('*, animes(*)')
+        query = self.client.table('airing_schedule').select('*')
         query = self._apply_dataset_version_filter(query)
         result = query.gte('airing_at', start_of_day.isoformat())\
             .lte('airing_at', end_of_day.isoformat())\
@@ -372,7 +405,7 @@ class SupabaseClient:
         from datetime import timedelta
         end_date = start_date + timedelta(days=7)
 
-        query = self.client.table('airing_schedule').select('*, animes(*)')
+        query = self.client.table('airing_schedule').select('*')
         query = self._apply_dataset_version_filter(query)
         result = query.gte('airing_at', start_date.isoformat())\
             .lt('airing_at', end_date.isoformat())\

--- a/src/supabase_tools.py
+++ b/src/supabase_tools.py
@@ -170,19 +170,18 @@ def get_weekly_schedule_supabase(weeks_offset: int = 0) -> Dict[str, Any]:
         airing_at = datetime.fromisoformat(item['airing_at'].replace('Z', '+00:00'))
         day_name = airing_at.strftime('%A').upper()
 
-        anime = item.get('animes', {})
         schedule_item = {
-            'schedule_id': item.get('id'),
+            'schedule_id': item.get('schedule_id') or item.get('id'),
             'anime_id': item.get('anime_id'),
-            'title': anime.get('title', 'Unknown'),
+            'title': item.get('title') or 'Unknown',
             'episode': item.get('episode'),
             'airing_at': int(airing_at.timestamp()),
             'airing_time': airing_at.strftime('%I:%M %p'),
             'airing_date': airing_at.strftime('%Y-%m-%d'),
-            'cover_image': anime.get('cover_image_large'),
-            'status': anime.get('status'),
-            'total_episodes': anime.get('episodes'),
-            'score': anime.get('score'),
+            'cover_image': item.get('cover_image'),
+            'status': item.get('anime_status'),
+            'total_episodes': item.get('total_episodes'),
+            'score': item.get('score'),
             'time_until_airing': int((airing_at - datetime.now(timezone.utc)).total_seconds()),
             'airing_status': _get_airing_status(airing_at),
             'airs_in_human': _format_time_until(airing_at)

--- a/src/sync_to_supabase.py
+++ b/src/sync_to_supabase.py
@@ -17,7 +17,7 @@ import os
 import sys
 import glob
 import argparse
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from typing import List, Dict, Any
 
 import pandas as pd
@@ -93,6 +93,63 @@ def filter_records_by_window(
     return filtered, archived_count
 
 
+def fetch_airing_schedule_items(
+    weeks_back: int = 2,
+    weeks_forward: int = 6,
+) -> List[Dict[str, Any]]:
+    """
+    Fetch the airing schedule from AniList for a rolling window around today
+    and shape rows for the airing_schedule table. Fetched week-by-week because
+    get_weekly_airing_schedule caps pagination per call.
+    """
+    import asyncio
+    from src.anilist_client import get_weekly_airing_schedule
+
+    now = datetime.utcnow()
+    week_start = now - timedelta(days=now.weekday(), hours=now.hour,
+                                 minutes=now.minute, seconds=now.second,
+                                 microseconds=now.microsecond)
+
+    async def fetch_all() -> List[Dict[str, Any]]:
+        items: List[Dict[str, Any]] = []
+        for offset in range(-weeks_back, weeks_forward):
+            start = week_start + timedelta(weeks=offset)
+            end = start + timedelta(days=7)
+            week_items = await get_weekly_airing_schedule(
+                int(start.timestamp()), int(end.timestamp())
+            )
+            items.extend(week_items)
+        return items
+
+    raw_items = asyncio.run(fetch_all())
+
+    rows: List[Dict[str, Any]] = []
+    seen: set[tuple[int, int]] = set()
+    for item in raw_items:
+        anime_id = item.get('anime_id')
+        episode = item.get('episode')
+        airing_at = item.get('airing_at')
+        if not anime_id or episode is None or not airing_at:
+            continue
+        key = (anime_id, episode)
+        if key in seen:
+            continue
+        seen.add(key)
+        rows.append({
+            'schedule_id': item.get('schedule_id'),
+            'anime_id': anime_id,
+            'episode': episode,
+            'airing_at': datetime.fromtimestamp(airing_at, tz=timezone.utc).isoformat(),
+            'time_until_airing': item.get('time_until_airing'),
+            'title': item.get('title'),
+            'cover_image': item.get('cover_image'),
+            'score': item.get('score'),
+            'total_episodes': item.get('total_episodes'),
+            'anime_status': item.get('status'),
+        })
+    return rows
+
+
 def build_version_name(csv_source: str | None) -> str:
     """Create a unique dataset version name for each sync attempt."""
     timestamp = datetime.utcnow().strftime('%Y%m%d_%H%M%S')
@@ -109,6 +166,7 @@ def sync_from_data(
     csv_source: str = None,
     window_start_year: int = DEFAULT_WINDOW_START_YEAR,
     window_end_year: int = DEFAULT_WINDOW_END_YEAR,
+    include_schedule: bool = True,
 ) -> Dict[str, Any]:
     """
     Sync a list of anime dicts to Supabase.
@@ -121,6 +179,7 @@ def sync_from_data(
         'window_records': 0,
         'archived_records': 0,
         'records_synced': 0,
+        'schedule_synced': 0,
         'new_records': 0,
         'updated_records': 0,
         'errors': [],
@@ -209,6 +268,20 @@ def sync_from_data(
                     "refusing to activate incomplete dataset version"
                 )
 
+            if include_schedule:
+                print("  Fetching airing schedule from AniList...")
+                schedule_rows = fetch_airing_schedule_items()
+                if not schedule_rows:
+                    raise RuntimeError(
+                        "AniList returned no airing schedule items; "
+                        "refusing to activate a version with an empty schedule"
+                    )
+                schedule_synced = client.upsert_schedule_batch(
+                    schedule_rows, version_id=version_id
+                )
+                result['schedule_synced'] = schedule_synced
+                print(f"  Airing schedule: {schedule_synced} episodes synced")
+
             if version_id is not None:
                 client.activate_dataset_version(
                     version_id,
@@ -223,8 +296,8 @@ def sync_from_data(
             client.complete_sync_log(
                 log_id,
                 records_processed=len(filtered_data),
-                records_inserted=synced,
-                records_updated=0,
+                records_inserted=new_count,
+                records_updated=updated_count,
                 new_records=new_count,
                 updated_records=updated_count,
                 details=details
@@ -253,6 +326,7 @@ def sync_from_csv(
     dry_run: bool = False,
     window_start_year: int = DEFAULT_WINDOW_START_YEAR,
     window_end_year: int = DEFAULT_WINDOW_END_YEAR,
+    include_schedule: bool = True,
 ) -> Dict[str, Any]:
     """Load CSV and sync to Supabase."""
     if not os.path.exists(csv_path):
@@ -270,6 +344,7 @@ def sync_from_csv(
         csv_source=csv_name,
         window_start_year=window_start_year,
         window_end_year=window_end_year,
+        include_schedule=include_schedule,
     )
 
 
@@ -281,6 +356,8 @@ def main():
                         help='Glob pattern for CSV files (used with --csv-dir)')
     parser.add_argument('--batch-size', type=int, default=100)
     parser.add_argument('--dry-run', action='store_true', help='Validate without writing')
+    parser.add_argument('--skip-schedule', action='store_true',
+                        help='Skip syncing the AniList airing schedule')
     parser.add_argument('--window-start-year', type=int, default=DEFAULT_WINDOW_START_YEAR)
     parser.add_argument('--window-end-year', type=int, default=DEFAULT_WINDOW_END_YEAR)
 
@@ -293,12 +370,14 @@ def main():
             args.dry_run,
             window_start_year=args.window_start_year,
             window_end_year=args.window_end_year,
+            include_schedule=not args.skip_schedule,
         )
         print(f"\nSync Summary:")
         print(f"  Total records: {result['total_records']}")
         print(f"  Featured window records: {result.get('window_records', 0)}")
         print(f"  Archived outside window: {result.get('archived_records', 0)}")
         print(f"  Records synced: {result['records_synced']}")
+        print(f"  Schedule episodes synced: {result.get('schedule_synced', 0)}")
         print(f"  New anime: {result.get('new_records', 0)}")
         print(f"  Updated anime: {result.get('updated_records', 0)}")
         if result.get('dataset_version'):
@@ -326,6 +405,7 @@ def main():
                 args.dry_run,
                 window_start_year=args.window_start_year,
                 window_end_year=args.window_end_year,
+                include_schedule=not args.skip_schedule,
             )
             total_synced += result['records_synced']
             total_errors.extend(result['errors'])

--- a/supabase/migrations/004_enable_rls.sql
+++ b/supabase/migrations/004_enable_rls.sql
@@ -1,0 +1,28 @@
+-- ============================================================================
+-- ROW LEVEL SECURITY
+-- Apps access Supabase server-side with the service key (bypasses RLS).
+-- The anon key gets read-only access to catalog tables and nothing else:
+-- no public policies on sync_log / dataset_versions means service-key only.
+-- ============================================================================
+
+ALTER TABLE public.animes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.airing_schedule ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.season_archive ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.sync_log ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.dataset_versions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "public read" ON public.animes
+    FOR SELECT USING (true);
+
+CREATE POLICY "public read" ON public.airing_schedule
+    FOR SELECT USING (true);
+
+CREATE POLICY "public read" ON public.season_archive
+    FOR SELECT USING (true);
+
+-- Pin search_path so these SECURITY-relevant functions can't be hijacked
+-- by objects in other schemas (Supabase linter 0011)
+ALTER FUNCTION public.get_distinct_genres() SET search_path = public;
+ALTER FUNCTION public.update_updated_at_column() SET search_path = public;
+ALTER FUNCTION public.get_active_dataset_version_id() SET search_path = public;
+ALTER FUNCTION public.activate_dataset_version(BIGINT) SET search_path = public;

--- a/supabase/migrations/005_denormalize_airing_schedule.sql
+++ b/supabase/migrations/005_denormalize_airing_schedule.sql
@@ -1,0 +1,20 @@
+-- ============================================================================
+-- DENORMALIZED AIRING SCHEDULE
+-- The schedule tab only needs display fields; storing them on the schedule
+-- row avoids joining animes (no FK relationship since versioning dropped the
+-- anime_id unique constraint) and keeps schedule rows self-contained even for
+-- shows outside the featured sync window (e.g. long-running 2025 anime).
+-- ============================================================================
+
+ALTER TABLE public.airing_schedule
+    ADD COLUMN IF NOT EXISTS title TEXT,
+    ADD COLUMN IF NOT EXISTS cover_image TEXT,
+    ADD COLUMN IF NOT EXISTS score NUMERIC,
+    ADD COLUMN IF NOT EXISTS total_episodes INTEGER,
+    ADD COLUMN IF NOT EXISTS anime_status TEXT;
+
+-- Recreate the view: it snapshotted the column list before the new columns
+CREATE OR REPLACE VIEW public.airing_schedule_active AS
+SELECT s.*
+FROM public.airing_schedule AS s
+WHERE s.dataset_version_id = public.get_active_dataset_version_id();


### PR DESCRIPTION
Follow-up to #15.

- Daily sync now loads the AniList airing schedule (rolling -2..+6 week window) into the same dataset version as the catalog, before the atomic activation — schedule and catalog flip together, and a failed schedule fetch keeps yesterday's version live.
- `airing_schedule` rows are denormalized (title/cover/score/episodes), so no join with `animes` is needed.
- New `/api/schedule` Next.js route serves a whole calendar range from `airing_schedule_active` in one query; `MonthlySchedule` makes one cached fetch per month instead of six sequential FastAPI calls (the slow loading bar is gone).
- RLS enabled on all public tables (migrations 004), anon is read-only on catalog tables, `sync_log`/`dataset_versions` are service-key only; function search_path pinned.
- `sync_log` now records real inserted/updated counts.
- GitHub Actions bumped for the Node 20 deprecation (checkout@v5, setup-python@v6, github-script@v7).

Migrations 004/005 are already applied to the live DB; sync + frontend tested end-to-end in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)