### PR TITLE
Migration 006: security_invoker views

### DIFF
--- a/supabase/migrations/006_view_security_invoker.sql
+++ b/supabase/migrations/006_view_security_invoker.sql
@@ -1,0 +1,13 @@
+-- ============================================================================
+-- VIEW SECURITY INVOKER
+-- The *_active views defaulted to definer semantics (Supabase linter 0010),
+-- which would let them bypass table RLS. With invoker semantics the querying
+-- role's RLS applies; dataset_versions needs a read policy so
+-- get_active_dataset_version_id() still resolves for the anon role.
+-- ============================================================================
+
+ALTER VIEW public.animes_active SET (security_invoker = true);
+ALTER VIEW public.airing_schedule_active SET (security_invoker = true);
+
+CREATE POLICY "public read" ON public.dataset_versions
+    FOR SELECT USING (true);


### PR DESCRIPTION
Resolves the security_definer_view linter errors: `animes_active` / `airing_schedule_active` now run with invoker semantics, and `dataset_versions` gets a public read policy so the active-version lookup works for anon. Already applied to the live DB; production verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)